### PR TITLE
Update runtime to 40

### DIFF
--- a/org.gnome.PowerStats.json
+++ b/org.gnome.PowerStats.json
@@ -2,7 +2,7 @@
   "app-id": "org.gnome.PowerStats",
   "sdk": "org.gnome.Sdk",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "3.36",
+  "runtime-version": "40",
   "command": "gnome-power-statistics",
   "finish-args": [
     "--share=ipc",


### PR DESCRIPTION
This MR fixes the following warning:
```
Info: org.gnome.Platform//3.36 is end-of-life, with reason:
   The GNOME 3.36 runtime is no longer supported as of February 13, 2021. Please ask your application developer to migrate to a supported platform.
Applications using this runtime:
   org.gnome.PowerStats
```