### PR TITLE
Update runtime version to 43

### DIFF
--- a/org.gnome.PowerStats.json
+++ b/org.gnome.PowerStats.json
@@ -2,7 +2,7 @@
   "app-id": "org.gnome.PowerStats",
   "sdk": "org.gnome.Sdk",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "42",
+  "runtime-version": "43",
   "command": "gnome-power-statistics",
   "finish-args": [
     "--share=ipc",


### PR DESCRIPTION
I'm guessing this had to be done with release 43.0 and it's the only gnome package that I have that still depends on the gnome platform 42.