### PR TITLE
Update to GNOME 45 runtime and upower 1.90.2

### DIFF
--- a/org.gnome.PowerStats.json
+++ b/org.gnome.PowerStats.json
@@ -38,6 +38,11 @@
       ],
       "sources": [
         {
+          "x-checker-data": {
+            "type": "anitya",
+            "project-id": 5056,
+            "url-template": "https://gitlab.freedesktop.org/upower/upower/-/archive/v$version/upower-v$version.tar.gz"
+          },
           "type": "archive",
           "url": "https://gitlab.freedesktop.org/upower/upower/uploads/93cfe7c8d66ed486001c4f3f55399b7a/upower-0.99.11.tar.xz",
           "sha256": "64b5ffbfccd5bdb15d925777979a4dbee1a957f9eaeb158dc76175267eddbdef"

--- a/org.gnome.PowerStats.json
+++ b/org.gnome.PowerStats.json
@@ -49,6 +49,11 @@
       "buildsystem": "meson",
       "sources": [
         {
+          "x-checker-data": {
+              "type": "gnome",
+              "name": "gnome-power-manager",
+              "stable-only": true
+          },
           "type": "archive",
           "url": "https://download.gnome.org/sources/gnome-power-manager/43/gnome-power-manager-43.0.tar.xz",
           "sha256": "7daab48bbddb30e9df2aba650cb60d05e667c9f885ace6a0a1e7950e0cbdd32f"

--- a/org.gnome.PowerStats.json
+++ b/org.gnome.PowerStats.json
@@ -2,7 +2,7 @@
   "app-id": "org.gnome.PowerStats",
   "sdk": "org.gnome.Sdk",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "43",
+  "runtime-version": "45",
   "command": "gnome-power-statistics",
   "finish-args": [
     "--share=ipc",

--- a/org.gnome.PowerStats.json
+++ b/org.gnome.PowerStats.json
@@ -1,73 +1,73 @@
 {
-  "app-id": "org.gnome.PowerStats",
-  "sdk": "org.gnome.Sdk",
-  "runtime": "org.gnome.Platform",
-  "runtime-version": "45",
-  "command": "gnome-power-statistics",
-  "finish-args": [
-    "--share=ipc",
-    "--socket=wayland",
-    "--socket=fallback-x11",
-    "--system-talk-name=org.freedesktop.UPower"
-  ],
-  "cleanup": [
-     "*.la",
-    "/include",
-    "/share/man"
-  ],
-  "modules": [
-    "shared-modules/gudev/gudev.json",
-    "shared-modules/libusb/libusb.json",
-    {
-      "name": "upower",
-      "config-opts": [
-        "--with-systemdsystemunitdir=no",
-        "--with-systemdutildir=no"
-      ],
-      "cleanup": [
-        "/bin/upower",
-        "/etc/dbus-1",
-        "/etc/UPower",
-        "/libexec",
-        "/libexec/rules.d",
-        "/lib/girepository-1.0",
-        "/lib/pkgconfig",
-        "/share/dbus-1",
-        "/share/gir-1.0",
-        "/var"
-      ],
-      "sources": [
+    "app-id": "org.gnome.PowerStats",
+    "sdk": "org.gnome.Sdk",
+    "runtime": "org.gnome.Platform",
+    "runtime-version": "45",
+    "command": "gnome-power-statistics",
+    "finish-args": [
+        "--share=ipc",
+        "--socket=wayland",
+        "--socket=fallback-x11",
+        "--system-talk-name=org.freedesktop.UPower"
+    ],
+    "cleanup": [
+        "*.la",
+        "/include",
+        "/share/man"
+    ],
+    "modules": [
+        "shared-modules/gudev/gudev.json",
+        "shared-modules/libusb/libusb.json",
         {
-          "x-checker-data": {
-            "type": "anitya",
-            "project-id": 5056,
-            "url-template": "https://gitlab.freedesktop.org/upower/upower/-/archive/v$version/upower-v$version.tar.gz"
-          },
-          "type": "archive",
-          "url": "https://gitlab.freedesktop.org/upower/upower/uploads/93cfe7c8d66ed486001c4f3f55399b7a/upower-0.99.11.tar.xz",
-          "sha256": "64b5ffbfccd5bdb15d925777979a4dbee1a957f9eaeb158dc76175267eddbdef"
-        }
-      ]
-    },
-    {
-      "name": "gnome-power-manager",
-      "buildsystem": "meson",
-      "sources": [
-        {
-          "x-checker-data": {
-              "type": "gnome",
-              "name": "gnome-power-manager",
-              "stable-only": true
-          },
-          "type": "archive",
-          "url": "https://download.gnome.org/sources/gnome-power-manager/43/gnome-power-manager-43.0.tar.xz",
-          "sha256": "7daab48bbddb30e9df2aba650cb60d05e667c9f885ace6a0a1e7950e0cbdd32f"
+            "name": "upower",
+            "config-opts": [
+                "--with-systemdsystemunitdir=no",
+                "--with-systemdutildir=no"
+            ],
+            "cleanup": [
+                "/bin/upower",
+                "/etc/dbus-1",
+                "/etc/UPower",
+                "/libexec",
+                "/libexec/rules.d",
+                "/lib/girepository-1.0",
+                "/lib/pkgconfig",
+                "/share/dbus-1",
+                "/share/gir-1.0",
+                "/var"
+            ],
+            "sources": [
+                {
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 5056,
+                        "url-template": "https://gitlab.freedesktop.org/upower/upower/-/archive/v$version/upower-v$version.tar.gz"
+                    },
+                    "type": "archive",
+                    "url": "https://gitlab.freedesktop.org/upower/upower/uploads/93cfe7c8d66ed486001c4f3f55399b7a/upower-0.99.11.tar.xz",
+                    "sha256": "64b5ffbfccd5bdb15d925777979a4dbee1a957f9eaeb158dc76175267eddbdef"
+                }
+            ]
         },
         {
-          "type": "patch",
-          "path": "0001-trivial-Fix-up-appdata-release-date.patch"
+            "name": "gnome-power-manager",
+            "buildsystem": "meson",
+            "sources": [
+                {
+                    "x-checker-data": {
+                        "type": "gnome",
+                        "name": "gnome-power-manager",
+                        "stable-only": true
+                    },
+                    "type": "archive",
+                    "url": "https://download.gnome.org/sources/gnome-power-manager/43/gnome-power-manager-43.0.tar.xz",
+                    "sha256": "7daab48bbddb30e9df2aba650cb60d05e667c9f885ace6a0a1e7950e0cbdd32f"
+                },
+                {
+                    "type": "patch",
+                    "path": "0001-trivial-Fix-up-appdata-release-date.patch"
+                }
+            ]
         }
-      ]
-    }
-  ]
+    ]
 }

--- a/org.gnome.PowerStats.json
+++ b/org.gnome.PowerStats.json
@@ -20,9 +20,14 @@
         "shared-modules/libusb/libusb.json",
         {
             "name": "upower",
+            "buildsystem": "meson",
             "config-opts": [
-                "--with-systemdsystemunitdir=no",
-                "--with-systemdutildir=no"
+                "-Dsystemdsystemunitdir=no",
+                "-Dudevrulesdir=/app/lib/udev/rules.d",
+                "-Dudevhwdbdir=/app/lib/udev/hwdb.d",
+                "-Dman=false",
+                "-Dgtk-doc=false",
+                "-Dintrospection=disabled"
             ],
             "cleanup": [
                 "/bin/upower",
@@ -32,6 +37,7 @@
                 "/libexec/rules.d",
                 "/lib/girepository-1.0",
                 "/lib/pkgconfig",
+                "/lib/udev",
                 "/share/dbus-1",
                 "/share/gir-1.0",
                 "/var"
@@ -44,8 +50,8 @@
                         "url-template": "https://gitlab.freedesktop.org/upower/upower/-/archive/v$version/upower-v$version.tar.gz"
                     },
                     "type": "archive",
-                    "url": "https://gitlab.freedesktop.org/upower/upower/uploads/93cfe7c8d66ed486001c4f3f55399b7a/upower-0.99.11.tar.xz",
-                    "sha256": "64b5ffbfccd5bdb15d925777979a4dbee1a957f9eaeb158dc76175267eddbdef"
+                    "url": "https://gitlab.freedesktop.org/upower/upower/-/archive/v1.90.2/upower-v1.90.2.tar.gz",
+                    "sha256": "5c4e736648f0c89d2368fbbe1e6fc0598a1565c4b435bade1d65e890259fb759"
                 }
             ]
         },


### PR DESCRIPTION
Plus, update to a new gudev (needed for new upower), and add
flatpak-external-data-checker annotations to automate some future updates.

Depends on:
- [x] https://github.com/flathub/shared-modules/pull/279

Fixes #11 